### PR TITLE
Add compatibility to coap-pubsub function

### DIFF
--- a/include/coap.hrl
+++ b/include/coap.hrl
@@ -5,7 +5,7 @@
 -define(DEFAULT_MAX_AGE, 60).
 
 -record(coap_message, {type, method, id, token = <<>>, options = [], payload = <<>>}).
--record(coap_content, {etag, max_age = ?DEFAULT_MAX_AGE, format, payload = <<>>}).
+-record(coap_content, {etag, max_age = ?DEFAULT_MAX_AGE, format, location_path, payload = <<>>}).
 
 -type coap_message() :: #coap_message{}.
 -type coap_content() :: #coap_content{}.

--- a/src/coap_message.erl
+++ b/src/coap_message.erl
@@ -87,18 +87,20 @@ get_content(#coap_message{options=Options, payload=Payload}) ->
                end,
         max_age = proplists:get_value(max_age, Options, ?DEFAULT_MAX_AGE),
         format = proplists:get_value(content_format, Options),
+        location_path = proplists:get_value(location_path, Options, []),
         payload = Payload}.
 
 set_content(Content, Msg) ->
     set_content(Content, undefined, Msg).
 
 % segmentation not requested and not required
-set_content(#coap_content{etag=ETag, max_age=MaxAge, format=Format, payload=Payload}, undefined, Msg)
-        when byte_size(Payload) =< ?MAX_BLOCK_SIZE ->
+set_content(#coap_content{etag=ETag, max_age=MaxAge, format=Format, location_path = LocPath, payload=Payload}, undefined, Msg)
+    when byte_size(Payload) =< ?MAX_BLOCK_SIZE ->
     set(etag, [ETag],
         set(max_age, MaxAge,
             set(content_format, Format,
-                set_payload(Payload, Msg))));
+                set(location_path, LocPath,
+                    set_payload(Payload, Msg)))));
 % segmentation not requested, but required (late negotiation)
 set_content(Content, undefined, Msg) ->
     set_content(Content, {0, true, ?MAX_BLOCK_SIZE}, Msg);

--- a/src/coap_message_parser.erl
+++ b/src/coap_message_parser.erl
@@ -87,6 +87,7 @@ methods() -> [
     {{2,03}, {ok, valid}},
     {{2,04}, {ok, changed}},
     {{2,05}, {ok, content}},
+    {{2,07}, {ok, nocontent}},
     {{2,31}, {ok, continue}}, % block
     % error is a tuple {error, ...}
     {{4,00}, {error, bad_request}},

--- a/src/coap_resource.erl
+++ b/src/coap_resource.erl
@@ -16,7 +16,7 @@
     [coap_uri()].
 
 % GET handler
--callback coap_get(coap_channel_id(), [binary()], [binary()], [binary()]) ->
+-callback coap_get(coap_channel_id(), [binary()], [binary()], [binary()], any()) ->
     coap_content() | {'error', atom()}.
 % POST handler
 -callback coap_post(coap_channel_id(), [binary()], [binary()], coap_content()) ->

--- a/src/coap_resource.erl
+++ b/src/coap_resource.erl
@@ -29,7 +29,7 @@
     'ok' | {'error', atom()}.
 
 % observe request handler
--callback coap_observe(coap_channel_id(), [binary()], [binary()], boolean()) ->
+-callback coap_observe(coap_channel_id(), [binary()], [binary()], boolean(), any()) ->
     {'ok', any()} | {'error', atom()}.
 % cancellation request handler
 -callback coap_unobserve(any()) ->

--- a/src/coap_responder.erl
+++ b/src/coap_responder.erl
@@ -139,8 +139,9 @@ process_request(ChId, Request, State) ->
     check_resource(ChId, Request, State).
 
 check_resource(ChId, Request, State=#state{prefix=Prefix, module=Module}) ->
+    Content = coap_message:get_content(Request),
     case invoke_callback(Module, coap_get,
-            [ChId, Prefix, uri_suffix(Prefix, Request), uri_query(Request)]) of
+            [ChId, Prefix, uri_suffix(Prefix, Request), uri_query(Request), Content]) of
         R1=#coap_content{} ->
             check_preconditions(ChId, Request, R1, State);
         R2={error, not_found} ->
@@ -199,12 +200,12 @@ handle_method(_ChId, Request, _Resource, State) ->
 handle_observe(ChId, Request=#coap_message{options=Options}, Content=#coap_content{},
         State=#state{prefix=Prefix, module=Module, observer=undefined}) ->
     % the first observe request from this user to this resource
-    case invoke_callback(Module, coap_observe, [ChId, Prefix, uri_suffix(Prefix, Request), requires_ack(Request)]) of
-        {ok, ObState} ->
+    case invoke_callback(Module, coap_observe, [ChId, Prefix, uri_suffix(Prefix, Request), requires_ack(Request), Content]) of
+        {ok, ObState, Code, Content2} ->
             Uri = proplists:get_value(uri_path, Options, []),
             pg2:create({coap_observer, Uri}),
             ok = pg2:join({coap_observer, Uri}, self()),
-            return_resource(Request, Content, State#state{observer=Request, obstate=ObState});
+            return_resource([], Request, {ok, Code}, Content2, State#state{observer=Request, obstate=ObState});
         {error, method_not_allowed} ->
             % observe is not supported, fallback to standard get
             return_resource(Request, Content, State#state{observer=undefined});
@@ -253,6 +254,8 @@ handle_put(ChId, Request, Resource, State=#state{prefix=Prefix, module=Module}) 
             [ChId, Prefix, uri_suffix(Prefix, Request), Content]) of
         ok ->
             return_response(Request, created_or_changed(Resource), State);
+        {ok, Code, Content2} ->
+            return_resource([], Request, {ok, Code}, Content2, State);
         {error, Error} ->
             return_response(Request, {error, Error}, State);
         {error, Error, Reason} ->


### PR DESCRIPTION
In order to implement the ietf-core-pubsub spec, modify some details of gen_coap.