### PR TITLE
Coap concurrent improvement

### DIFF
--- a/src/coap_channel.erl
+++ b/src/coap_channel.erl
@@ -154,9 +154,10 @@ handle_info(Info, State) ->
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
-terminate(_Reason, #state{sup=SupPid, sock=SockPid, cid=ChId}) ->
+terminate(_Reason, #state{sup=SupPid, cid=ChId}) ->
     %io:fwrite("channel ~p finished ~p~n", [ChId, Reason]),
-    SockPid ! {terminated, SupPid, ChId},
+    coap_udp_socket:delete_channel(ChId),
+    exit(SupPid, normal),
     ok.
 
 

--- a/src/coap_channel_sup.erl
+++ b/src/coap_channel_sup.erl
@@ -11,7 +11,7 @@
 -module(coap_channel_sup).
 -behaviour(supervisor).
 
--export([start_link/2, init/1]).
+-export([start_link/2, init/1, get_channel/1]).
 
 start_link(SockPid, ChId) ->
     {ok, SupPid} = supervisor:start_link(?MODULE, []),
@@ -28,6 +28,12 @@ start_link(SockPid, ChId) ->
 init([]) ->
     % crash of any worker will terminate the supervisor and invoke start_link/2 again
     {ok, {{one_for_all, 0, 1}, []}}.
+
+
+get_channel(SupPid) ->
+    List = supervisor:which_children(SupPid),
+    [ChPid] = [Pid || {coap_channel, Pid, _, _} <- List],
+    ChPid.
 
 
 % end of file

--- a/src/coap_server.erl
+++ b/src/coap_server.erl
@@ -20,6 +20,8 @@
 
 -include("coap.hrl").
 
+-define(TAB, ets_coap_channel_pid).
+
 start() ->
     start(normal, []).
 
@@ -31,7 +33,8 @@ stop(_Pid) ->
 
 
 init([]) ->
-    {ok, {{one_for_all, 3, 10}, [
+    create_client_tab(),
+    {ok, {{one_for_one, 3, 10}, [
         {coap_server_registry,
             {coap_server_registry, start_link, []},
             permanent, 5000, worker, []},
@@ -75,5 +78,17 @@ child(SupPid, Id) ->
     [Pid] = [Pid || {Id1, Pid, _, _} <- supervisor:which_children(SupPid),
         Id1 =:= Id],
     Pid.
+
+
+
+create_client_tab() ->
+    case ets:info(?TAB, name) of
+        undefined ->
+            ets:new(?TAB, [set, named_table, public, {write_concurrency, true}]);
+        _ ->
+            ok
+    end.
+
+
 
 % end of file

--- a/src/coap_udp_socket.erl
+++ b/src/coap_udp_socket.erl
@@ -102,7 +102,12 @@ handle_info({udp, Socket, PeerIP, PeerPortNo, Data}, State=#state{pool=PoolPid})
                 {error, {already_started, SuPid}} ->
                     % this process is created, and its pid is writing into ets table now, and find_channel() will return undefined
                     ChPid = coap_channel_sup:get_channel(SuPid),
-                    ChPid ! {datagram, Data},
+                    case is_pid(ChPid) of
+                        true  ->
+                            ChPid ! {datagram, Data};
+                        false ->
+                            io:format("ChId=~p, coap_channel_sup pid=~p, coap_channel pid=~p~n", [ChId, SuPid, ChPid])
+                    end,
                     {noreply, State};
                 % drop this packet
                 {error, _} ->

--- a/src/coap_udp_socket.erl
+++ b/src/coap_udp_socket.erl
@@ -15,8 +15,18 @@
 
 -export([start_link/0, start_link/2, get_channel/2, close/1]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, code_change/3, terminate/2]).
+-export([delete_channel/1]).
 
--record(state, {sock, chans, pool}).
+-record(state, {sock, pool}).
+
+-define(TAB, ets_coap_channel_pid).
+
+-define(LINUX_SOL_SOCKET, 1).
+-define(LINUX_SO_REUSEPORT, 15).
+-define(UNIX_SOL_SOCKET, 16#FFFF).
+-define(UNIX_SO_REUSEPORT, 16#0200).
+
+-define(OPT_BUFFER, 65536*8).
 
 % client
 start_link() ->
@@ -35,27 +45,29 @@ close(Pid) ->
 
 
 init([InPort]) ->
-    {ok, Socket} = gen_udp:open(InPort, [binary, {active, true}, {reuseaddr, true}]),
+    {ok, Socket} = gen_udp:open(InPort, [binary, {active, once}, {buffer, ?OPT_BUFFER*2}, {recbuf, ?OPT_BUFFER}, {sndbuf, ?OPT_BUFFER}, {reuseaddr, true}]++reuseport()),
     %{ok, InPort2} = inet:port(Socket),
     %error_logger:info_msg("coap listen on *:~p~n", [InPort2]),
-    {ok, #state{sock=Socket, chans=dict:new()}};
+    {ok, #state{sock=Socket}};
 
 init([InPort, SupPid]) ->
     gen_server:cast(self(), {set_pool, SupPid}),
     init([InPort]).
 
-handle_call({get_channel, ChId}, _From, State=#state{chans=Chans, pool=undefined}) ->
-    case find_channel(ChId, Chans) of
+handle_call({get_channel, ChId}, _From, State=#state{pool=undefined}) ->
+    case find_channel(ChId) of
         {ok, Pid} ->
             {reply, {ok, Pid}, State};
         undefined ->
             {ok, _, Pid} = coap_channel_sup:start_link(self(), ChId),
-            {reply, {ok, Pid}, store_channel(ChId, Pid, State)}
+            store_channel(ChId, Pid),
+            {reply, {ok, Pid}, State}
     end;
 handle_call({get_channel, ChId}, _From, State=#state{pool=PoolPid}) ->
     case coap_channel_sup_sup:start_channel(PoolPid, ChId) of
         {ok, _, Pid} ->
-            {reply, {ok, Pid}, store_channel(ChId, Pid, State)};
+            store_channel(ChId, Pid),
+            {reply, {ok, Pid}, State};
         Error ->
             {reply, Error, State}
     end;
@@ -72,9 +84,10 @@ handle_cast(Request, State) ->
     io:fwrite("coap_udp_socket unknown cast ~p~n", [Request]),
     {noreply, State}.
 
-handle_info({udp, _Socket, PeerIP, PeerPortNo, Data}, State=#state{chans=Chans, pool=PoolPid}) ->
+handle_info({udp, Socket, PeerIP, PeerPortNo, Data}, State=#state{pool=PoolPid}) ->
     ChId = {PeerIP, PeerPortNo},
-    case find_channel(ChId, Chans) of
+    inet:setopts(Socket, [{active, once}]),
+    case find_channel(ChId) of
         % channel found in cache
         {ok, Pid} ->
             Pid ! {datagram, Data},
@@ -84,7 +97,13 @@ handle_info({udp, _Socket, PeerIP, PeerPortNo, Data}, State=#state{chans=Chans, 
                 % new channel created
                 {ok, _, Pid} ->
                     Pid ! {datagram, Data},
-                    {noreply, store_channel(ChId, Pid, State)};
+                    store_channel(ChId, Pid),
+                    {noreply, State};
+                {error, {already_started, SuPid}} ->
+                    % this process is created, and its pid is writing into ets table now, and find_channel() will return undefined
+                    ChPid = coap_channel_sup:get_channel(SuPid),
+                    ChPid ! {datagram, Data},
+                    {noreply, State};
                 % drop this packet
                 {error, _} ->
                     {noreply, State}
@@ -97,10 +116,6 @@ handle_info({udp, _Socket, PeerIP, PeerPortNo, Data}, State=#state{chans=Chans, 
 handle_info({datagram, {PeerIP, PeerPortNo}, Data}, State=#state{sock=Socket}) ->
     ok = gen_udp:send(Socket, PeerIP, PeerPortNo, Data),
     {noreply, State};
-handle_info({terminated, SupPid, ChId}, State=#state{chans=Chans}) ->
-    Chans2 = dict:erase(ChId, Chans),
-    exit(SupPid, normal),
-    {noreply, State#state{chans=Chans2}};
 handle_info(Info, State) ->
     io:fwrite("coap_udp_socket unexpected ~p~n", [Info]),
     {noreply, State}.
@@ -113,19 +128,35 @@ terminate(_Reason, #state{sock=Sock}) ->
     ok.
 
 
-find_channel(ChId, Chans) ->
-    case dict:find(ChId, Chans) of
+find_channel(ChId) ->
+    case ets:lookup(?TAB, ChId) of
         % there is a channel in our cache, but it might have crashed
-        {ok, Pid} ->
+        [{ChId, Pid}] ->
             case erlang:is_process_alive(Pid) of
-                true -> {ok, Pid};
+                true  -> {ok, Pid};
                 false -> undefined
             end;
         % we got data via a new channel
-        error -> undefined
+        [] -> undefined
     end.
 
-store_channel(ChId, Pid, State=#state{chans=Chans}) ->
-    State#state{chans=dict:store(ChId, Pid, Chans)}.
+store_channel(ChId, Pid) ->
+    ets:insert(?TAB, {ChId, Pid}).
+
+delete_channel(ChId) ->
+    ets:delete(?TAB, ChId).
+
+
+reuseport() ->
+    reuseport(os:type()).
+
+reuseport({unix, linux})   -> [{raw, ?LINUX_SOL_SOCKET, ?LINUX_SO_REUSEPORT, <<1:32/native>>}];  % require linux kernel v3.9 and later version
+reuseport({unix, darwin})  -> [{raw, ?UNIX_SOL_SOCKET, ?UNIX_SO_REUSEPORT, <<1:32/native>>}];
+reuseport({unix, freebsd}) -> reuseport({unix, darwin});
+reuseport({unix, openbsd}) -> reuseport({unix, darwin});
+reuseport({unix, netbsd})  -> reuseport({unix, darwin});
+reuseport(_)               -> [].
+
+
 
 % end of file


### PR DESCRIPTION
1) Utilize reuseport option and multi-sockets.
2) Use ets table to store coap_channel pid.