### PR TITLE
FIX: coap_channel_sup is unable to be terminated.

### DIFF
--- a/src/coap_udp_socket.erl
+++ b/src/coap_udp_socket.erl
@@ -99,7 +99,7 @@ handle_info({datagram, {PeerIP, PeerPortNo}, Data}, State=#state{sock=Socket}) -
     {noreply, State};
 handle_info({terminated, SupPid, ChId}, State=#state{chans=Chans}) ->
     Chans2 = dict:erase(ChId, Chans),
-    exit(SupPid, normal),
+    exit(SupPid, kill),  % FIXME: an ugly way to terminate a supervisor
     {noreply, State#state{chans=Chans2}};
 handle_info(Info, State) ->
     io:fwrite("coap_udp_socket unexpected ~p~n", [Info]),


### PR DESCRIPTION
Use 'kill' signal, instead of 'normal' signal, to brutal kill supervisor. This is a temporary solution.